### PR TITLE
set contextIsolation to false for Electron 12.x+ /image-shrink

### DIFF
--- a/buglogger/main.js
+++ b/buglogger/main.js
@@ -25,9 +25,10 @@ function createMainWindow() {
     height: 800,
     show: false,
     backgroundColor: 'white',
-    icon: `${__dirname}/assets/icons/icon.png',
+    icon: `${__dirname}/assets/icons/icon.png`,
     webPreferences: {
       nodeIntegration: true,
+      contextIsolation: false
     },
   })
 

--- a/image-shrink/main.js
+++ b/image-shrink/main.js
@@ -26,6 +26,7 @@ function createMainWindow() {
     backgroundColor: 'white',
     webPreferences: {
       nodeIntegration: true,
+      contextIsolation: false
     },
   })
 

--- a/sys-top/MainWindow.js
+++ b/sys-top/MainWindow.js
@@ -12,6 +12,7 @@ class MainWindow extends BrowserWindow {
       opacity: 0.9,
       webPreferences: {
         nodeIntegration: true,
+        contextIsolation: false
       },
     })
 


### PR DESCRIPTION
In version 12 of Electron, contextIsolation is defaulted to 'true' which prevents the application from accessing the 'path' and 'os' modules.